### PR TITLE
Add FFmpeg to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Make sure you have the following installed on your machine:
 
 - [Python](https://www.python.org/downloads/) (<b>Only compatible with version 3.11</b>)
 - [pip](https://pip.pypa.io/en/stable/installation/)
+- [ffmpeg](https://ffmpeg.org/download.html)
 
 ### Installing Dependencies
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Make sure you have the following installed on your machine:
 
 - [Python](https://www.python.org/downloads/) (<b>Only compatible with version 3.11</b>)
 - [pip](https://pip.pypa.io/en/stable/installation/)
-- [ffmpeg](https://ffmpeg.org/download.html)
+- [FFmpeg](https://ffmpeg.org/download.html)
 
 ### Installing Dependencies
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy==1.26.2
 Pillow==10.1.0
 pydub==0.25.1
 Requests==2.31.0
+opencv-python==4.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ numpy==1.26.2
 Pillow==10.1.0
 pydub==0.25.1
 Requests==2.31.0
-opencv-python==4.9.0


### PR DESCRIPTION
Add FFmpeg to prerequisites after noticing in my own usage of the app it was required, and pointing it out in #12. 

Did not edit the requirements.txt file adding OpenCV as #15 addressed that already.