### PR TITLE
Fix opencv requirement version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ numpy==1.26.2
 Pillow==10.1.0
 pydub==0.25.1
 Requests==2.31.0
-opencv-python==4.9.80
+opencv-python==4.9.0.80


### PR DESCRIPTION
Looks like this was a typo. The latest version is as listed : 4.9.0.80 https://pypi.org/project/opencv-python/4.9.0.80/